### PR TITLE
url prefix needs to be an absolute url

### DIFF
--- a/deploy/binder_config.yml
+++ b/deploy/binder_config.yml
@@ -14,7 +14,7 @@ binderhub:
     path: "/etc/binderhub/templates/templates"
     static:
       path: "/etc/binderhub/templates/static"
-      urlPrefix: extra_static/
+      urlPrefix: /extra_static/
   initContainers:
     - name: git-clone-templates
       image: alpine/git


### PR DESCRIPTION
to avoid 404s on pages other than the landing page, due to a relative url:

<img width="539" alt="screen shot 2018-11-08 at 15 52 13" src="https://user-images.githubusercontent.com/151929/48206293-637f6080-e36e-11e8-8f52-b9f0e7a0c8a3.png">

closes #12