### PR TITLE
add staging configs

### DIFF
--- a/deploy/staging_config.yml
+++ b/deploy/staging_config.yml
@@ -1,0 +1,94 @@
+binderhub:
+  build:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: user-pool
+
+  nodeSelector:
+     cloud.google.com/gke-nodepool: default-pool
+
+  registry:
+    prefix: gcr.io/pangeo-181919/pangeo-binder
+    enabled: true
+
+  template:
+    path: "/etc/binderhub/templates/templates"
+    static:
+      path: "/etc/binderhub/templates/static"
+      urlPrefix: extra_static/
+  initContainers:
+    - name: git-clone-templates
+      image: alpine/git
+      args:
+        - clone
+        - --single-branch
+        - --branch=master
+        - --
+        - https://github.com/pangeo-data/pangeo-custom-binderhub-templates.git
+        - /etc/binderhub/templates
+
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+        - name: custom-templates
+          mountPath: /etc/binderhub/templates
+  extraVolumes:
+    - name: custom-templates
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: custom-templates
+      mountPath: /etc/binderhub/templates
+
+  hub:
+    url: http://hub.staging.binder.pangeo.io
+  build:
+    repo2dockerImage: jupyter/repo2docker:5cdd0ee
+  jupyterhub:
+    cull:
+      # cull every 11 minutes so it is out of phase
+      # with the proxy check-routes interval of five minutes
+      every: 660
+      timeout: 600
+      # maxAge is 3 hours: 3 * 3600 = 10800
+      maxAge: 10800
+    singleuser:
+      # start jupyter notebook
+      cmd: jupyter-lab
+      cloudMetadata:
+        enabled: true
+      cpu:
+        limit: 4
+        guarantee: 1
+      memory:
+        limit: 26G
+        guarantee: 4G
+      nodeSelector:
+        cloud.google.com/gke-nodepool: user-pool
+    hub:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: default-pool
+      resources:
+        requests:
+          cpu: "0.25"
+          memory: 1Gi
+        limits:
+          cpu: "2"
+          memory: 1Gi
+    proxy:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: default-pool
+      chp:
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: "0.25"
+          limits:
+            memory: 512Mi
+            cpu: "0.5"
+      nginx:
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: "0.25"
+          limits:
+            memory: 1Gi
+            cpu: 1

--- a/deploy/staging_namespace.yaml
+++ b/deploy/staging_namespace.yaml
@@ -1,0 +1,10 @@
+{
+  "kind": "Namespace",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "staging",
+    "labels": {
+      "name": "staging"
+    }
+  }
+}


### PR DESCRIPTION
I've just deployed a second pangeo-binder using these configs. I plan to use this for upcoming development work. 

- kubernetes namespace: `staging`
- live @: staging.binder.pangeo.io