### PR TITLE
add ClusterIP config

### DIFF
--- a/helm-chart/pangeo-binder/values.yaml
+++ b/helm-chart/pangeo-binder/values.yaml
@@ -64,6 +64,8 @@ binderhub:
           memory: 1Gi
 
     proxy:
+      service:
+        type: ClusterIP
       chp:
         resources:
           requests:
@@ -103,6 +105,8 @@ binderhub:
   extraVolumeMounts:
     - name: custom-templates
       mountPath: /etc/binderhub/custom
+  service:
+    type: ClusterIP
 
 nginx-ingress:
   rbac:


### PR DESCRIPTION
closes #29.

Currently failing with this error:

```
Error: UPGRADE FAILED: Service "proxy-public" is invalid: [spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP', spec.ports[1].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'] && Service "binder" is invalid: spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'
```