### PR TITLE
Updating pod scheduling

### DIFF
--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -30,7 +30,10 @@ binderhub:
         - secretName: kubelego-tls-jupyterhub-staging
           hosts:
             - hub.staging.binder.pangeo.io
-
+    scheduling:
+      userScheduler:
+        enabled: true
+        replicas: 1
 kube-lego:
   nodeSelector:
     hub.jupyter.org/node-purpose: core

--- a/helm-chart/pangeo-binder/requirements.yaml
+++ b/helm-chart/pangeo-binder/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: binderhub
-  version: 0.2.0-82fc209
+  version: 0.2.0-9f83710
   repository: https://jupyterhub.github.io/helm-chart/
   import-values:
     - child: rbac

--- a/helm-chart/pangeo-binder/requirements.yaml
+++ b/helm-chart/pangeo-binder/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: binderhub
-  version: 0.2.0-10ac4d8
+  version: 0.2.0-82fc209
   repository: https://jupyterhub.github.io/helm-chart/
   import-values:
     - child: rbac

--- a/helm-chart/pangeo-binder/values.yaml
+++ b/helm-chart/pangeo-binder/values.yaml
@@ -5,7 +5,7 @@ binderhub:
   config:
     BinderHub:
       use_registry: true
-      build_image: jupyter/repo2docker:df89849e
+      build_image: jupyter/repo2docker:91309cab
       per_repo_quota: 150
       template_path: /etc/binderhub/custom/templates
       extra_static_path: /etc/binderhub/custom/static

--- a/helm-chart/pangeo-binder/values.yaml
+++ b/helm-chart/pangeo-binder/values.yaml
@@ -41,6 +41,9 @@ binderhub:
         enabled: true
       userPlaceholder:
         enabled: false
+      userPods:
+        nodeAffinity:
+          matchNodePurpose: require
     singleuser:
       serviceAccountName: daskkubernetes
       # start jupyter lab


### PR DESCRIPTION
I've been working today on getting the final pieces of the k8s scheduling implemented in our binder deployment. This has resulted in a few merged PRs upstream (https://github.com/jupyterhub/binderhub/pull/853, https://github.com/jupyterhub/binderhub/pull/856). I've deployed these changes manually and I'm opening this PR to ask for some help debugging a few things. 

### Problem 1: DinD DaemonSet is not scheduling
I'm trying to get the DinD DaemonSet to tolerate the `hub.jupyter.org_dedicated=user:NO_SCHEDULE` taint that is set on the `user-pool` (https://github.com/jupyterhub/binderhub/pull/856). However, new DinD pods are not coming up when a new user-pool node comes live. Then build tasks fail because they can't mount the docker socket.

```
==> v1beta1/DaemonSet
NAME                   DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SELECTOR                      AGE
staging-dind           0        0        0      0           0          hub.jupyter.org/node-purpose=user  3m30s
staging-image-cleaner  0        0        0      0           0          hub.jupyter.org/node-purpose=user  3m30s
```

Asking for help from @yuvipanda @consideRatio @betatim