### PR TITLE
remove sphinx pin

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==1.6.5
+sphinx
 sphinx_bootstrap_theme
 sphinx-copybutton


### PR DESCRIPTION
The version of sphinx-copybutton we were pulling wasn't compatible with sphinx 1.6.5. Just unpinning everything for now.