### PR TITLE
Update docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -234,7 +234,8 @@ texinfo_documents = [
 intersphinx_mapping = {'jupyter': ('https://jupyter.readthedocs.io/en/latest/', None),
                        'dask': ('http://dask.pydata.org/en/latest/', None),
                        'dask-kubernetes': ('https://dask-kubernetes.readthedocs.io/en/latest/', None),
-                       'pangeo': ('http://pangeo.io/', None)}
+                       'pangeo': ('http://pangeo.io/', None),
+                       'dask-gateway': ('https://gateway.dask.org/', None)}
 # -- Options for todo extension ----------------------------------------------
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,8 @@ Configuring Dask
 
 The Pangeo Binder is configured to include a Dask Gateway server, which allows
 users to create Dask Clusters for distributed computation. To create the clusters,
-**you must include the dask-gateway in your environment file**.
+we recommend depending on the ``pangeo-notebook`` metapackage. This metapackage
+brings in `several dependencies`_ including dask-gateway and dask-labextension.
 
 .. code-block:: yaml
 
@@ -60,8 +61,7 @@ users to create Dask Clusters for distributed computation. To create the cluster
    channels:
      - conda-forge
    dependencies:
-     - dask-gateway
-     - dask-labextension
+     - pangeo-notebook
      # Additional packages for your analysis...
 
 The version of dask-gateway pre-configured on the Binder must
@@ -128,3 +128,4 @@ Examples using Pangeo's Binder
 .. _Kubernetes: https://kubernetes.io/
 .. _Pangeo Example Notebooks: https://github.com/pangeo-data/pangeo-example-notebooks
 .. _Dask Gateway: https://gateway.dask.org/
+.. _several dependencies: https://github.com/conda-forge/pangeo-notebook-feedstock/blob/master/recipe/meta.yaml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ About Pangeo's Binder
 Much like mybinder.org_, the `Pangeo's`_ BinderHub deployment (`binder.pangeo.io`_)
 allows users to create and share custom computing environments. The main distinction
 between the two BinderHubs is that Pangeo's BinderHub allows users to perform
-scalable computations using the dask-kubernetes package.
+scalable computations using `Dask Gateway`_.
 
 For more information on the Pangeo project, check out the `online documentation`_.
 
@@ -47,60 +47,43 @@ After running the cookiecutter command, simply follow the command line instructi
 to compete setting up your repository. Add some Jupyter Notebooks, configure your
 environment and push the whole thing to GitHub.
 
-Configuring dask-kubernetes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Configuring Dask
+~~~~~~~~~~~~~~~~
 
-`Dask-kubernetes`_ is a library designed to deploy dask-distributed using
-Kubernetes_. When using dask-kubernetes on binder, you need to specify some
-basic configuration options. An example of a file named `.dask/config.yaml`.
+The Pangeo Binder is configured to include a Dask Gateway server, which allows
+users to create Dask Clusters for distributed computation. To create the clusters,
+**you must include the dask-gateway in your environment file**.
 
-.. .dask/config.yaml
+.. code-block:: yaml
 
-::
+   # binder/environment.yml
+   channels:
+     - conda-forge
+   dependencies:
+     - dask-gateway
+     - dask-labextension
+     # Additional packages for your analysis...
 
-  # .dask/config.yaml
-  fuse_subgraphs: False
-  fuse_ave_width: 0
+The version of dask-gateway pre-configured on the Binder must
+match the dask-gateway in the ``environment.yml``. That's currently
+``dask-gateway==0.6.1``.
 
-  distributed:
-    logging:
-      bokeh: critical
+With Dask Gateway installed, your notebooks can create clusters:
 
-    dashboard:
-      link: /user/{JUPYTERHUB_USER}/proxy/{port}/status
+.. code-block:: python
 
-    admin:
-      tick:
-        limit: 5s
+   from dask_gateway import Gateway
+   from dask.distributed import Client
 
-  kubernetes:
-    count:
-      max: 50
-    worker-template:
-      metadata:
-      spec:
-        nodeSelector:
-          dask-worker: True
-        restartPolicy: Never
-        containers:
-        - args:
-            - dask-worker
-            - --nthreads
-            - '2'
-            - --no-bokeh
-            - --memory-limit
-            - 7GB
-            - --death-timeout
-            - '60'
-          image: ${JUPYTER_IMAGE_SPEC}
-          name: dask-worker
-          resources:
-            limits:
-              cpu: "1.75"
-              memory: 7G
-            requests:
-              cpu: 1
-              memory: 7G
+   gateway = Gateway()
+   cluster = gateway.new_cluster()
+
+   client = Client(cluster)
+
+You can use :meth:`dask_gateway.GatewayCluster.scale` to scale the number
+of workers manually, or set the cluster to adaptive mode with
+:meth:`dask_gateway.GatewayCluster.adapt` to scale up and down based on
+computational load.
 
 start script
 ~~~~~~~~~~~~
@@ -144,3 +127,4 @@ Examples using Pangeo's Binder
 .. _Dask-kubernetes: https://dask-kubernetes.readthedocs.io/en/latest/
 .. _Kubernetes: https://kubernetes.io/
 .. _Pangeo Example Notebooks: https://github.com/pangeo-data/pangeo-example-notebooks
+.. _Dask Gateway: https://gateway.dask.org/


### PR DESCRIPTION
staging.binder.pangeo.io should be up and running with dask gateway. This updates the docs for when we're ready to apply things to dask-gateway.

This diff (`git diff 3b7813 deploy/staging.yaml pangeo-binder/`) gives a decent idea of the cumulative change, aside from the additional secrets.

```diff
diff --git a/deploy/staging.yaml b/deploy/staging.yaml
index 64816db..1d82ae6 100644
--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -34,6 +34,11 @@ binderhub:
     scheduling:
       userScheduler:
         enabled: false
+    singleuser:
+      extraEnv:
+        DASK_GATEWAY__ADDRESS: "https://hub.staging.binder.pangeo.io/services/dask-gateway/"
+        DASK_GATEWAY__PROXY_ADDRESS: "tls://scheduler-public-staging-dask-gateway:8786"
+
     hub:
       resources:
         requests:
@@ -42,7 +47,7 @@ binderhub:
       services:
         dask-gateway:
           # This makes the gateway available at ${HUB_URL}/services/dask-gateway
-          url: http://web-public-pangeo-binder-staging-dask-gateway
+          url: http://web-public-staging-dask-gateway
 
     proxy:
       chp:
diff --git a/pangeo-binder/requirements.yaml b/pangeo-binder/requirements.yaml
index 1e26dc8..5cf5c23 100644
--- a/pangeo-binder/requirements.yaml
+++ b/pangeo-binder/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: binderhub
-  version: 0.2.0-n093.h7cfad48
+  version: 0.2.0-n132.h1a8ce62
   repository: https://jupyterhub.github.io/helm-chart/
   import-values:
     - child: rbac
@@ -12,3 +12,6 @@ dependencies:
 - name: nginx-ingress
   version: 0.20.0
   repository: https://kubernetes-charts.storage.googleapis.com
+- name: dask-gateway
+  version: "0.6.1"
+  repository: 'https://dask.org/dask-gateway-helm-repo/'
diff --git a/pangeo-binder/values.yaml b/pangeo-binder/values.yaml
index 662be7c..e63d836 100644
--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -4,7 +4,7 @@ binderhub:
 
   config:
     BinderHub:
-      build_image: jupyter/repo2docker:0.10.0-186.g900d280
+      build_image: jupyter/repo2docker:0.11.0-20.g070e4a9
       use_registry: true
       # use_named_servers: true  # turn back on to use auth
       # auth_enabled: true  # turn back on to use auth
@@ -59,6 +59,10 @@ binderhub:
         limit: 8G
         guarantee: 8G
       cmd: jupyter-lab
+      extraEnv:
+        DASK_GATEWAY__AUTH__TYPE: "jupyterhub"
+        DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
+
       # to make notebook servers aware of hub
       # cmd: jupyterhub-singleuser  # turn back on to use auth
       # start in jupyter lab
@@ -182,51 +186,54 @@ kube-lego:
   image:
     tag: 0.1.7
 
-gateway:
-  clusterManager:
-    image:  # TODO
-      name: pangeo/base-notebook
-      tag: 2019.12.24
-    clusterStartTimeout: 600
-    workerStartTimeout: 600
-    worker:
-      extraPodConfig:
-        tolerations:
-          - key: "k8s.dask.org_dedicated"
-            operator: "Equal"
-            value: "worker"
-    scheduler:
-      extraPodConfig:
-        tolerations:
-          - key: "k8s.dask.org_dedicated"
-            operator: "Equal"
-            value: "worker"
-  extraConfig:
-    # Use the mapping form, to support merging multiple values.yaml
-    optionHandler: |
-      from dask_gateway_server.options import Options, Integer, Float, String
+dask-gateway:
+  gateway:
+    loglevel: DEBUG
+    clusterManager:
+      image:
+        name: daskgateway/dask-gateway-server
+        tag: 0.6.1
+        pullPolicy: IfNotPresent
+      clusterStartTimeout: 600
+      workerStartTimeout: 600
+      worker:
+        extraPodConfig:
+          tolerations:
+            - key: "k8s.dask.org_dedicated"
+              operator: "Equal"
+              value: "worker"
+      scheduler:
+        extraPodConfig:
+          tolerations:
+            - key: "k8s.dask.org_dedicated"
+              operator: "Equal"
+              value: "worker"
+    extraConfig:
+      # Use the mapping form, to support merging multiple values.yaml
+      optionHandler: |
+        from dask_gateway_server.options import Options, Integer, Float, String
 
-      def option_handler(options):
-          if ":" not in options.image:
-              raise ValueError("When specifying an image you must also provide a tag")
-          return {
-              "worker_cores_limit": options.worker_cores,
-              "worker_cores": min(options.worker_cores / 2, 1),
-              "worker_memory": "%fG" % options.worker_memory,
-              "image": options.image,
-          }
-      c.DaskGateway.cluster_manager_options = Options(
-          Integer("worker_cores", 2, min=1, max=4, label="Worker Cores"),
-          Float("worker_memory", 4, min=1, max=8, label="Worker Memory (GiB)"),
-          String("image", default="pangeo/base-notebook:2019.12.24", label="Image"),
-          handler=option_handler,
-      )
+        def option_handler(options):
+            if ":" not in options.image:
+                raise ValueError("When specifying an image you must also provide a tag")
+            return {
+                "worker_cores_limit": options.worker_cores,
+                "worker_cores": min(options.worker_cores / 2, 1),
+                "worker_memory": "%fG" % options.worker_memory,
+                "image": options.image,
+            }
+        c.DaskGateway.cluster_manager_options = Options(
+            Integer("worker_cores", 2, min=1, max=4, label="Worker Cores"),
+            Float("worker_memory", 4, min=1, max=8, label="Worker Memory (GiB)"),
+            String("image", default="pangeo/base-notebook:2019.12.24", label="Image"),
+            handler=option_handler,
+        )
 
-    userLimts: |
-      c.UserLimits.max_cores = 100
-      c.UserLimits.max_memory = "400 G"
-      c.UserLimits.max_clusters = 1
+      userLimts: |
+        c.UserLimits.max_cores = 100
+        c.UserLimits.max_memory = "400 G"
+        c.UserLimits.max_clusters = 1
 
-    tlsURL: |
-      if isinstance(c.DaskGateway.public_connect_url, str):
-          c.DaskGateway.public_connect_url += "/services/dask-gateway"
+      tlsURL: |
+        if isinstance(c.DaskGateway.public_connect_url, str):
+            c.DaskGateway.public_connect_url += "/services/dask-gateway"

```



cc @jhamman 
