### PR TITLE
[WIP] daskkubernetes sa to pangeo sa

### DIFF
--- a/deploy-aws/staging.yaml
+++ b/deploy-aws/staging.yaml
@@ -11,7 +11,7 @@ binderhub:
       use_registry: true
   nodeSelector:
     hub.jupyter.org/node-purpose: core
-  
+
   ingress:
     enabled: true
     hosts:
@@ -54,12 +54,12 @@ binderhub:
            hosts:
             - hub.staging.aws-uswest2-binder.pangeo.io
     singleuser:
+      serviceAccountName: pangeo
       extraEnv:
         DASK_GATEWAY__ADDRESS: "https://hub.staging.aws-uswest2-binder.pangeo.io/services/dask-gateway/"
-        DASK_GATEWAY__PROXY_ADDRESS: "tls://scheduler-public-staging-dask-gateway:8786" 
+        DASK_GATEWAY__PROXY_ADDRESS: "tls://scheduler-public-staging-dask-gateway:8786"
     hub:
       services:
         dask-gateway:
           # This makes the gateway available at ${HUB_URL}/services/dask-gateway
           url: http://web-public-staging-dask-gateway
-

--- a/k8s-aws/readme.md
+++ b/k8s-aws/readme.md
@@ -46,6 +46,13 @@ kubectl apply -f binderhub-issuer-${CIRCLE_BRANCH}.yaml
 ```
 You should now have a functioning binderhub at https://staging.aws-uswest2-binder.pangeo.io !!!
 
+##### link IAM role to pangeo service account
+For singleuser notebook pods and dask worker pods 
+see https://eksctl.io/usage/iamserviceaccounts/
+```
+eksctl create iamserviceaccount --config-file=eksctl-config.yml --override-existing-serviceaccounts
+```
+
 
 ##### Removing things:
 you can get rid of resources created with `kubectl apply` with `kubectl delete`:
@@ -56,4 +63,9 @@ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.
 Or tear everything down with
 ```
 helm delete staging -n staging
+```
+
+Other cheatsheet commands:
+```
+eksctl delete iamserviceaccount --cluster pangeo-binder --name pangeo --namespace staging
 ```

--- a/pangeo-binder/templates/dask-kubernetes-rbac.yaml
+++ b/pangeo-binder/templates/dask-kubernetes-rbac.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.rbac.enabled -}}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: daskkubernetes
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: daskkubernetes
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: daskkubernetes
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: daskkubernetes
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods", "services"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods/log"]
+  verbs: ["get", "list"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: daskkubernetes
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: daskkubernetes
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: daskkubernetes
+roleRef:
+  kind: Role
+  name: daskkubernetes
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/pangeo-binder/templates/pangeo-rbac.yaml
+++ b/pangeo-binder/templates/pangeo-rbac.yaml
@@ -2,11 +2,11 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: daskkubernetes
+  name: pangeo
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: daskkubernetes
+    component: pangeo
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 
@@ -15,38 +15,35 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: daskkubernetes
+  name: pangeo
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: daskkubernetes
+    component: pangeo
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["pods", "services"]
-  verbs: ["get", "list", "watch", "create", "delete"]
-- apiGroups: [""] # "" indicates the core API group
-  resources: ["pods/log"]
-  verbs: ["get", "list"]
+  resources: [""]
+  verbs: [""]
 
 ---
 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: daskkubernetes
+  name: pangeo
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: daskkubernetes
+    component: pangeo
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: daskkubernetes
+  name: pangeo
 roleRef:
   kind: Role
-  name: daskkubernetes
+  name: pangeo
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/pangeo-binder/templates/pangeo-rbac.yaml
+++ b/pangeo-binder/templates/pangeo-rbac.yaml
@@ -9,41 +9,4 @@ metadata:
     component: pangeo
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: pangeo
-  namespace: {{ .Release.Namespace }}
-  labels:
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: pangeo
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-rules:
-- apiGroups: [""] # "" indicates the core API group
-  resources: [""]
-  verbs: [""]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: pangeo
-  namespace: {{ .Release.Namespace }}
-  labels:
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: pangeo
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-subjects:
-- kind: ServiceAccount
-  name: pangeo
-roleRef:
-  kind: Role
-  name: pangeo
-  apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -197,16 +197,14 @@ dask-gateway:
       clusterStartTimeout: 600
       workerStartTimeout: 600
       worker:
+        securityContext:
+          runAsGroup: 1000
+          runAsUser: 1000
         extraPodConfig:
           serviceAccountName: pangeo
           automountServiceAccountToken: true
           securityContext:
-            fsGroup: 100
-# jupyter singleuser container has: 
-#          containers:
-#            securityContext:
-#              runAsGroup: 0
-#              runAsUser: 1000
+            fsGroup: 1000
           tolerations:
             - key: "k8s.dask.org/dedicated"
               operator: "Equal"

--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -197,9 +197,10 @@ dask-gateway:
       clusterStartTimeout: 600
       workerStartTimeout: 600
       worker:
-        securityContext:
-          runAsGroup: 1000
-          runAsUser: 1000
+        extraContainerConfig:
+          securityContext:
+            runAsGroup: 1000
+            runAsUser: 1000
         extraPodConfig:
           serviceAccountName: pangeo
           automountServiceAccountToken: true

--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -199,6 +199,7 @@ dask-gateway:
       worker:
         extraPodConfig:
           serviceAccountName: pangeo
+          automountServiceAccountToken: true
           tolerations:
             - key: "k8s.dask.org/dedicated"
               operator: "Equal"

--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -200,6 +200,13 @@ dask-gateway:
         extraPodConfig:
           serviceAccountName: pangeo
           automountServiceAccountToken: true
+          securityContext:
+            fsGroup: 100
+# jupyter singleuser container has: 
+#          containers:
+#            securityContext:
+#              runAsGroup: 0
+#              runAsUser: 1000
           tolerations:
             - key: "k8s.dask.org/dedicated"
               operator: "Equal"

--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -50,7 +50,7 @@ binderhub:
           matchNodePurpose: require
     singleuser:
       # https://github.com/pangeo-data/pangeo-binder/issues/129
-      serviceAccountName: daskkubernetes
+      serviceAccountName: pangeo
       cloudMetadata:
         enabled: true
       cpu:
@@ -137,7 +137,7 @@ binderhub:
   extraVolumeMounts:
     - name: custom-templates
       mountPath: /etc/binderhub/custom
-  
+
   dind:
     enabled: true
     daemonset:
@@ -173,7 +173,7 @@ nginx-ingress:
       limits:
         cpu: 0.5
         memory: 240Mi
-   
+
     service:
       # Preserve client IPs
       externalTrafficPolicy: Local
@@ -198,7 +198,7 @@ dask-gateway:
       workerStartTimeout: 600
       worker:
         extraPodConfig:
-#          serviceAccountName: pangeo
+          serviceAccountName: pangeo
           tolerations:
             - key: "k8s.dask.org/dedicated"
               operator: "Equal"


### PR DESCRIPTION
Changes to remove daskkubernetes service account (closes https://github.com/pangeo-data/pangeo-binder/issues/129). I'd love to merge this asap @jhamman and @TomAugspurger, but it will break KubeCluster and force people to use Dask gateway: 
```
gateway = Gateway()  # connect to Gateway
cluster = gateway.new_cluster()  # create cluster
```

Need some advice on how this all comes together. I'm confused as to how files in the template/ directory get filled in and applied. For the role do we still need explicit permissions would not listing anything be ok?
```
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: pangeo
  namespace: {{ .Release.Namespace }}
  labels:
    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
    component: pangeo
    heritage: {{ .Release.Service }}
    release: {{ .Release.Name }}
rules:
- apiGroups: [""] # "" indicates the core API group
  resources: [""]
  verbs: [""]
```

Also not sure what this importing of rbac does:
https://github.com/pangeo-data/pangeo-binder/blob/da809585b68d50134ea0fd545a220ba186caaedd/pangeo-binder/requirements.yaml#L3-L8
