### PR TITLE
Add username label to scheduler and worker pods.

### DIFF
--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -65,6 +65,7 @@ binderhub:
       extraEnv:
         DASK_GATEWAY__AUTH__TYPE: "jupyterhub"
         DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
+        DASK_GATEWAY__CLUSTER__OPTIONS__USERNAME: '{JUPYTERHUB_USER}'
 
       # to make notebook servers aware of hub
       # cmd: jupyterhub-singleuser  # turn back on to use auth
@@ -248,18 +249,28 @@ dask-gateway:
         def option_handler(options):
             if ":" not in options.image:
                 raise ValueError("When specifying an image you must also provide a tag")
+
+            extra_labels = {
+                "jupyterhub/username": options.username
+            }
+
             return {
                 "worker_cores_limit": options.worker_cores,
                 "worker_cores": min(options.worker_cores / 2, 1),
                 "worker_memory": "%fG" % options.worker_memory,
                 "image": options.image,
+                "scheduler_extra_pod_labels": extra_labels,
+                "worker_extra_pod_labels": extra_labels,
             }
+
         c.Backend.cluster_options = Options(
             Integer("worker_cores", 2, min=1, max=4, label="Worker Cores"),
             Float("worker_memory", 4, min=1, max=8, label="Worker Memory (GiB)"),
             String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
+            String("username", default="", label="Username"),
             handler=option_handler,
         )
+
 
       # TODO: replace with some k8s things
       # resource quota. per namespace.

--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -65,7 +65,6 @@ binderhub:
       extraEnv:
         DASK_GATEWAY__AUTH__TYPE: "jupyterhub"
         DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
-        DASK_GATEWAY__CLUSTER__OPTIONS__USERNAME: '{JUPYTERHUB_USER}'
 
       # to make notebook servers aware of hub
       # cmd: jupyterhub-singleuser  # turn back on to use auth
@@ -246,32 +245,29 @@ dask-gateway:
       optionHandler: |
         from dask_gateway_server.options import Options, Integer, Float, String
 
-        def option_handler(options):
-            if ":" not in options.image:
-                raise ValueError("When specifying an image you must also provide a tag")
-
-            extra_labels = {
-                "jupyterhub/username": options.username
-            }
-
-            return {
-                "worker_cores_limit": options.worker_cores,
-                "worker_cores": min(options.worker_cores / 2, 1),
-                "worker_memory": "%fG" % options.worker_memory,
-                "image": options.image,
-                "scheduler_extra_pod_labels": extra_labels,
-                "worker_extra_pod_labels": extra_labels,
-            }
-
-        c.Backend.cluster_options = Options(
-            Integer("worker_cores", 2, min=1, max=4, label="Worker Cores"),
-            Float("worker_memory", 4, min=1, max=8, label="Worker Memory (GiB)"),
-            String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
-            String("username", default="", label="Username"),
-            handler=option_handler,
-        )
-
-
+        def cluster_options(user):
+           def option_handler(options):
+               if ":" not in options.image:
+                   raise ValueError("When specifying an image you must also provide a tag")
+               extra_labels = {
+                   "jupyterhub/username": user.name
+               }
+               return {
+                   "worker_cores_limit": options.worker_cores,
+                   "worker_cores": min(options.worker_cores / 2, 1),
+                   "worker_memory": "%fG" % options.worker_memory,
+                   "image": options.image,
+                   "scheduler_extra_pod_labels": extra_labels,
+                   "worker_extra_pod_labels": extra_labels,
+               }
+           return Options(
+               Integer("worker_cores", 2, min=1, max=4, label="Worker Cores"),
+               Float("worker_memory", 4, min=1, max=8, label="Worker Memory (GiB)"),
+               String("image", default="pangeo/pangeo-notebook:latest", label="Image"),
+               handler=option_handler,
+           )
+        
+        c.Backend.cluster_options = cluster_options
       # TODO: replace with some k8s things
       # resource quota. per namespace.
       # on binder, so might need some thought.


### PR DESCRIPTION
This helps a bit with #143, since we can at least see which binder repos are associated with lingering pods.

@jcrist if you have a chance, can you comment on the approach here? The general desire is a way to get a piece of metadata from the *client* inserted into the Backend's configuration. Is there a cleaner way to do that than adding an option that then becomes visible to the user? The current setup should work just fine though.