### PR TITLE
Update staging ingress

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,7 @@
+Additional deployment things for hub.binder.pangeo.io
+
+
+```python
+kubectl apply -f deploy/nginx-ingress-staging.yaml 
+helm install stable/nginx-ingress --name binderhub-proxy --namespace staging -f deploy/nginx-ingress-staging.yaml
+```

--- a/deploy/binderhub-issuer-staging.yaml
+++ b/deploy/binderhub-issuer-staging.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: letsencrypt-production
+  namespace: staging
+spec:
+  acme:
+    # You must replace this email address with your own.
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: tom.w.augspurger@gmail.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # Secret resource used to store the account's private key.
+      name: letsencrypt-staging
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/deploy/nginx-ingress-staging.yaml
+++ b/deploy/nginx-ingress-staging.yaml
@@ -1,0 +1,4 @@
+controller:
+  service:
+    loadBalancerIP: 35.224.187.103
+

--- a/deploy/nginx-ingress.yaml
+++ b/deploy/nginx-ingress.yaml
@@ -1,4 +1,0 @@
-controller:
-  service:
-    loadBalancerIP: 35.224.187.103
-

--- a/deploy/nginx-ingress.yaml
+++ b/deploy/nginx-ingress.yaml
@@ -1,0 +1,4 @@
+controller:
+  service:
+    loadBalancerIP: 35.224.187.103
+

--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -13,8 +13,20 @@ binderhub:
     hub.jupyter.org/node-purpose: core
 
   ingress:
+    enabled: true
     hosts:
       - staging.binder.pangeo.io
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "true"
+      cert-manager.io/issuer: letsencrypt-production
+      https:
+        enabled: true
+        type: nginx
+    tls:
+      - secretName: staging-binder-pangeo-io-tls
+        hosts:
+          - staging.binder.pangeo.io
 
   dind:
     hostLibDir: /var/lib/dind/staging
@@ -25,12 +37,21 @@ binderhub:
       nodeSelector:
         hub.jupyter.org/node-purpose: core
     ingress:
+      enabled: true
       hosts:
         - hub.staging.binder.pangeo.io
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        kubernetes.io/tls-acme: "true"
+        cert-manager.io/issuer: letsencrypt-production
+        https:
+          enabled: true
+          type: nginx
       tls:
-        - secretName: kubelego-tls-jupyterhub-staging
-          hosts:
+         - secretName: hub-staging-binder-pangeo-io-tls
+           hosts:
             - hub.staging.binder.pangeo.io
+
     scheduling:
       userScheduler:
         enabled: false
@@ -60,9 +81,6 @@ binderhub:
           requests:
             memory: 100Mi
             cpu: "0.1"
-kube-lego:
-  nodeSelector:
-    hub.jupyter.org/node-purpose: core
 
 nginx-ingress:
   controller:
@@ -99,3 +117,19 @@ prometheus-operator:
         - secretName: grafana.staging.binder.binder.io-tls
           hosts:
             - grafana.staging.binder.binder.io
+
+ingress:
+  enabled: true
+  hosts:
+     - staging.binder.pangeo.io
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/issuer: letsencrypt-production
+    https:
+      enabled: true
+      type: nginx
+  tls:
+    - secretName: staging-binder-pangeo-io-tls
+      hosts:
+       - staging.binder.pangeo.io

--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -48,8 +48,8 @@ binderhub:
           enabled: true
           type: nginx
       tls:
-         - secretName: hub-staging-binder-pangeo-io-tls
-           hosts:
+        - secretName: hub-staging-binder-pangeo-io-tls
+          hosts:
             - hub.staging.binder.pangeo.io
 
     scheduling:

--- a/pangeo-binder/requirements.yaml
+++ b/pangeo-binder/requirements.yaml
@@ -1,20 +1,14 @@
 # requirements.yaml
 dependencies:
 - name: binderhub
-  version: 0.2.0-n132.h1a8ce62
+  version: 0.2.0-n217.h35366ea
   repository: https://jupyterhub.github.io/helm-chart/
   import-values:
     - child: rbac
       parent: rbac
-- name: kube-lego
-  version: 0.4.2
-  repository: https://kubernetes-charts.storage.googleapis.com
 - name: nginx-ingress
   version: 1.34.2
   repository: https://kubernetes-charts.storage.googleapis.com
 - name: dask-gateway
-  version: "0.7.1"
+  version: "0.8.0"
   repository: 'https://dask.org/dask-gateway-helm-repo/'
-- name: prometheus-operator
-  version: "9.3.1"
-  repository: https://kubernetes-charts.storage.googleapis.com

--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -20,7 +20,7 @@ binderhub:
       kubernetes.io/ingress.class: nginx
     https:
       enabled: true
-      type: kube-lego
+      type: nginx
   jupyterhub:
     ingress:
         enabled: true
@@ -181,15 +181,6 @@ nginx-ingress:
     service:
       # Preserve client IPs
       externalTrafficPolicy: Local
-
-kube-lego:
-  config:
-    LEGO_EMAIL: jhamman@ucar.edu
-    LEGO_URL: https://acme-v01.api.letsencrypt.org/directory
-  rbac:
-    create: true
-  image:
-    tag: 0.1.7
 
 dask-gateway:
   gateway:

--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -187,7 +187,7 @@ dask-gateway:
     prefix: "/services/dask-gateway"
     image:
       name: daskgateway/dask-gateway-server
-      tag: 0.7.1
+      tag: 0.8.0
       pullPolicy: IfNotPresent
 
     backend:


### PR DESCRIPTION
This hopefully resolves the deployment issues we're having on staging.

1. Updated ingress to not use kube-lego anymore
2. Updated binder hub version
3. Updated dask-gateway version