### PR TITLE
require dask-gateway>0.9

### DIFF
--- a/pangeo-binder/requirements.yaml
+++ b/pangeo-binder/requirements.yaml
@@ -10,5 +10,5 @@ dependencies:
   version: 1.34.2
   repository: https://kubernetes-charts.storage.googleapis.com
 - name: dask-gateway
-  version: "0.8.0"
+  version: "0.9.0"
   repository: 'https://dask.org/dask-gateway-helm-repo/'

--- a/pangeo-binder/values.yaml
+++ b/pangeo-binder/values.yaml
@@ -65,6 +65,9 @@ binderhub:
       extraEnv:
         DASK_GATEWAY__AUTH__TYPE: "jupyterhub"
         DASK_GATEWAY__CLUSTER__OPTIONS__IMAGE: '{JUPYTER_IMAGE_SPEC}'
+        DASK_DISTRIBUTED__DASHBOARD_LINK: '/user/{JUPYTERHUB_USER}/proxy/{port}/status'
+        DASK_LABEXTENSION__FACTORY__MODULE: 'dask_gateway'
+        DASK_LABEXTENSION__FACTORY__CLASS: 'GatewayCluster'
 
       # to make notebook servers aware of hub
       # cmd: jupyterhub-singleuser  # turn back on to use auth
@@ -187,7 +190,7 @@ dask-gateway:
     prefix: "/services/dask-gateway"
     image:
       name: daskgateway/dask-gateway-server
-      tag: 0.8.0
+      tag: 0.9.0
       pullPolicy: IfNotPresent
 
     backend:


### PR DESCRIPTION
goes along with https://github.com/pangeo-data/pangeo-cloud-federation/pull/875 

this allows using images with dask-gateway>=0.9 . But this also might mean that images with dask-gateway<0.9 may no longer work? 

note that one advantage of this repository not explicitly using the daskhub chart (compared to the jupyterhubs https://github.com/pangeo-data/pangeo-cloud-federation/blob/d7deb23224604150b5380946367d0d95d42e45cb/pangeo-deploy/Chart.yaml#L6-L12) seems to be that we can upgrade dask-gateway without touching any of the jupyterhub pieces!

