### PR TITLE
bump autoscaler resource to avoid OOMKilled

### DIFF
--- a/k8s-aws/cluster-autoscaler.yml
+++ b/k8s-aws/cluster-autoscaler.yml
@@ -129,15 +129,15 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.14.7
+        - image: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.16.7
           name: cluster-autoscaler
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
           command:
             - ./cluster-autoscaler
             - --v=4


### PR DESCRIPTION
Applied this locally. See also https://github.com/pangeo-data/pangeo-cloud-federation/issues/969